### PR TITLE
Fix upload same file bug.

### DIFF
--- a/backend/webapp/src/main/resources/widgets/pbUpload/pbUpload.ctrl.js
+++ b/backend/webapp/src/main/resources/widgets/pbUpload/pbUpload.ctrl.js
@@ -85,5 +85,6 @@ function PbUploadCtrl($scope, $sce, $element, widgetNameFactory, $timeout, $log,
 
     form.triggerHandler('submit');
     form[0].submit();
+    form[0].reset();
   }
 }


### PR DESCRIPTION
Fix the following usecase:
- Upload A.png
- Clear the upload widget
- Upload again A.png 

The file is not uploaded.