### PR TITLE
fix(translate_ampersand): Using a workaround for strings with '&' in block translate

### DIFF
--- a/frontend/app/js/home/help-popup.html
+++ b/frontend/app/js/home/help-popup.html
@@ -91,12 +91,12 @@
                         Bonita 7.10 <i class="pull-right glyphicon" ng-class="{'glyphicon-chevron-down': status.bonita710open, 'glyphicon-chevron-right': !status.bonita710open}"></i>
                     </uib-accordion-heading>
                     <dt translate>Know your Business Data Model and retrieve Business Data information is simpler than never </dt>
-                    <p translate>With the new data model section, list your objects and drag&drop them into whiteboard (or create a new variable) to introspect your Business Data Model and simplify the retrieval of data by proposing an advanced wizard to configure it. Use this variable later as any other variable.</p>
+                    <p translate>With the new data model section, list your objects and drag&amp;drop them into whiteboard (or create a new variable) to introspect your Business Data Model and simplify the retrieval of data by proposing an advanced wizard to configure it. Use this variable later as any other variable.</p>
                     <dt translate>Improve collaboration on UID artifacts</dt>
                     <p translate>With the newer way to store variables and widgets, the diff and merge operations are clearer thanks to a multiline storage.</p>
 
                     <dt translate>Tabs Container advancement</dt>
-                    <p translate>Customize tab title or add css dynamically, hide or disable tabs according to the conditions are the new capabilities of each tab. Change tab format or build nice side menus thanks to vertical display, read this <a href="https://www.bonitasoft.com/bos_redirect.php?bos_redirect_id=712&bos_redirect_product=bos&bos_redirect_major_version=7.10">how to to learn more about customization.</a></p>
+                    <p translate>Customize tab title or add css dynamically, hide or disable tabs according to the conditions are the new capabilities of each tab. Change tab format or build nice side menus thanks to vertical display, read this <a href="https://www.bonitasoft.com/bos_redirect.php?bos_redirect_id=712&amp;bos_redirect_product=bos&amp;bos_redirect_major_version=7.10">how to to learn more about customization.</a></p>
 
                     <dt translate>Enhancements on table and data table</dt>
                     <p translate>
@@ -110,7 +110,7 @@
                     <dt translate>Easily create forms to edit business variables or documents, or display business variables in read-only
                     </dt>
                     <p translate>
-                        This improvement is visible when creating the form from Bonita Studio. It will automatically create new variables in the UI Designer and bind them with the related widgets. For more information, read the <a href="https://www.bonitasoft.com/bos_redirect.php?bos_redirect_id=693&bos_redirect_product=bos&bos_redirect_major_version=7.9">dedicated documentation.</a>
+                        This improvement is visible when creating the form from Bonita Studio. It will automatically create new variables in the UI Designer and bind them with the related widgets. For more information, read the <a href="https://www.bonitasoft.com/bos_redirect.php?bos_redirect_id=693&amp;bos_redirect_product=bos&amp;bos_redirect_major_version=7.9">dedicated documentation.</a>
                     </p>
                     <dt translate>Use provided UID widgets as a template for a custom widget</dt>
                     <p translate>
@@ -118,7 +118,7 @@
                     </p>
                     <dt translate>New embedded AngularJS filter to resolve the lazy references of a business object</dt>
                     <p translate>
-                        To improve the management of embedded objects with lazy references, create a variable using the | lazyRef filter for the object to retrieve. For more information, read the <a href="https://www.bonitasoft.com/bos_redirect.php?bos_redirect_id=692&bos_redirect_product=bos&bos_redirect_major_version=7.9">dedicated documentation.</a>
+                        To improve the management of embedded objects with lazy references, create a variable using the | lazyRef filter for the object to retrieve. For more information, read the <a href="https://www.bonitasoft.com/bos_redirect.php?bos_redirect_id=692&amp;bos_redirect_product=bos&amp;bos_redirect_major_version=7.9">dedicated documentation.</a>
                     </p>
                     <dt translate>Switch widget</dt>
                     <p translate>


### PR DESCRIPTION
- Issue from the angular-gettext dependency. See https://github.com/rubenv/angular-gettext/issues/178 for details
- For testing, don't forget to update lang-template-fr-FR.po accordingly