### PR TITLE
chore(action): Use last node version to upload pot and list dependencies

### DIFF
--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           # Mandatory to use a old node version with our actual dependencies
-          node-version: '8'
+          node-version: '14'
       - name: Install gettext
         run: sudo apt-get install gettext
       - name: Run Crowdin upload

--- a/.github/workflows/list-dependencies.yml
+++ b/.github/workflows/list-dependencies.yml
@@ -22,7 +22,7 @@ jobs:
           ref: ${{ github.event.inputs.tagVersion || github.ref }}
       - uses: actions/setup-node@v1
         with:
-          node-version: '12'
+          node-version: '14'
       - name: Generate reports
         run: mvn initialize -Pdependencies
       - name: Generate archives


### PR DESCRIPTION
* After work on UID, we could now use last version of node.