### PR TITLE
support duplicating components in editor

### DIFF
--- a/frontend/app/js/editor/editor.controller.js
+++ b/frontend/app/js/editor/editor.controller.js
@@ -57,6 +57,18 @@ angular.module('bonitasoft.designer.editor').controller('EditorCtrl', function($
     });
   });
 
+  keyBindingService.bind(['d', 'ctrl+d'], function(e) {
+    e.preventDefault();
+
+    if (!$scope.currentComponent) {
+      return;
+    }
+
+    $scope.$apply(function() {
+      $scope.duplicateCurrentComponent();
+    });
+  });
+
   keyBindingService.bind('right', function() {
     moveSelection(+1);
   });
@@ -77,7 +89,7 @@ angular.module('bonitasoft.designer.editor').controller('EditorCtrl', function($
   }
 
   $scope.$on('$destroy', function() {
-    keyBindingService.unbind(['del', 'right', 'left']);
+    keyBindingService.unbind(['del', 'right', 'd', 'ctrl+d', 'left']);
   });
 
   $scope.componentClasses = componentUtils.getResolutionClasses;
@@ -267,6 +279,24 @@ angular.module('bonitasoft.designer.editor').controller('EditorCtrl', function($
   };
 
   /**
+   * Duplicates the currently selected component, inserts it after the currently
+   * selected one and selects it.
+   */
+  $scope.duplicateCurrentComponent = function() {
+    var component = $scope.currentComponent;
+    var currentRow = component.$$parentContainerRow.row;
+    var componentIndex = currentRow.indexOf(component);
+    var newComponent = whiteboardComponentWrapper.wrapWidget(
+      component.$$widget,
+      angular.copy(component),
+      component.$$parentContainerRow
+    );
+    delete newComponent.reference;
+    arrays.insertAtPosition(newComponent, componentIndex, currentRow);
+    $scope.selectComponent(newComponent);
+  };
+
+  /**
    *
    * @returns {boolean}
    */
@@ -437,6 +467,7 @@ angular.module('bonitasoft.designer.editor').controller('EditorCtrl', function($
     componentClasses: $scope.componentClasses,
     removeCurrentRow: $scope.removeCurrentRow,
     removeCurrentComponent: $scope.removeCurrentComponent,
+    duplicateCurrentComponent: $scope.duplicateCurrentComponent,
     switchCurrentComponent: $scope.switchCurrentComponent,
     rowSize: $scope.rowSize,
     isCurrentRow: $scope.isCurrentRow,

--- a/frontend/app/js/editor/whiteboard/component-mover.directive.js
+++ b/frontend/app/js/editor/whiteboard/component-mover.directive.js
@@ -22,6 +22,7 @@ angular.module('bonitasoft.designer.editor.whiteboard').directive('componentMove
     scope: {
       component: '=',
       onDelete: '&',
+      onDuplicate: '&',
       onSwitch: '&'
     },
     templateUrl: 'js/editor/whiteboard/component-mover.html',

--- a/frontend/app/js/editor/whiteboard/component-mover.html
+++ b/frontend/app/js/editor/whiteboard/component-mover.html
@@ -3,5 +3,6 @@
     <button ng-if="moveLeftVisible()" ng-click="moveLeft()" class="fa fa-arrow-circle-left btn-caption move-left"  title="Move the component to the left"></button>
     <button ng-if="moveRightVisible()" ng-click="moveRight()" class="fa fa-arrow-circle-right btn-caption move-right" title="Move the component to the right"></button>
     <button ng-if="component.$$widget.type === 'widget'" ng-click="onSwitch()" class="fa fa-exchange btn-caption" title="Switch widget"></button>
+    <button ng-click="onDuplicate()" class="fa fa-files-o btn-caption" title="Duplicate"></button>
     <button ng-click="onDelete()" class="fa fa-times-circle btn-caption" title="Delete the component"></button>
 </section>

--- a/frontend/app/js/editor/whiteboard/component.html
+++ b/frontend/app/js/editor/whiteboard/component.html
@@ -1,5 +1,5 @@
 <div class="widget-wrapper">
-    <component-mover class="component-mover" component="component" on-delete="editor.removeCurrentComponent()" on-switch="editor.switchCurrentComponent()" ng-if="editor.isCurrentComponent(component)"></component-mover>
+    <component-mover class="component-mover" component="component" on-delete="editor.removeCurrentComponent()" on-duplicate="editor.duplicateCurrentComponent()" on-switch="editor.switchCurrentComponent()" ng-if="editor.isCurrentComponent(component)"></component-mover>
     <div class="widget-content"></div>
     <drop-zone editor="editor" row="row" container="container" component-index="componentIndex"></drop-zone>
 </div>

--- a/frontend/test/unit/editor/editor.controller.spec.js
+++ b/frontend/test/unit/editor/editor.controller.spec.js
@@ -1,4 +1,4 @@
-import aWidget from  '../utils/builders/WidgetElementBuilder';
+import aWidget from '../utils/builders/WidgetElementBuilder';
 
 describe('EditorCtrl', function() {
   var $scope, pageRepo, $q, $state, $window, componentUtils, whiteboardService, $timeout, widgetRepo;
@@ -333,6 +333,36 @@ describe('EditorCtrl', function() {
     expect(container.rows.length).toBe(1);
     expect(container.rows[0]).toBe(row1);
     expect(whiteboardService.triggerRowRemoved).not.toHaveBeenCalled();
+  });
+
+  it('should be able to duplicate the current component', function() {
+
+    var container = {
+      rows: [
+        []
+      ]
+    };
+
+    $scope.currentContainerRow = {
+      container: container,
+      row: container.rows[0]
+    };
+
+    var component = aWidget().withParentContainerRow($scope.currentContainerRow);
+
+    var dragData = {
+      create: function() {
+        return component;
+      }
+    };
+
+    $scope.addComponent(dragData, 0);
+    expect(container.rows[0].length).toBe(1);
+
+    $scope.duplicateCurrentComponent();
+
+    expect(container.rows[0].length).toBe(2);
+    expect($scope.currentComponent).not.toBe(component);
   });
 
   it('should remove the current component and trigger "removed" while removing it', function() {


### PR DESCRIPTION
Not too fixed on the current keyboard shortcuts (just pressing D, or Ctrl-D)

I'm not sure if I should be accessing the internals of the widget like I am doing here, or if I should abstract that away into some helper (if so and there is an existing one, I don't know which existing helper to put it in) - I needed to clear the internals like this to make sure that it doesn't have the same widget reference on multiple instances as well as in the saving that it didn't save the same reference twice (breaks rendering otherwise)

For rapidly creating a form with a few custom inputs this is a good time saver for me. Undo/redo support is something I would be quite interested in as well, but the code base didn't seem to be built for that yet and I would need a lot of time getting into the code.