### PR TITLE
chore(rebranding): update bonitasoft.com domain references to ofelia.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ You can also run the image on a fixed port, 8000 for example, with :
 [java]: https://www.java.com/fr/download/
 [docker]: https://www.docker.com/
 [studio-repo]: https://github.com/bonitasoft/bonita-studio
-[download]: https://www.bonitasoft.com/downloads
-[documentation]: https://documentation.bonitasoft.com
+[download]: https://www.ofelia.com/downloads
+[documentation]: https://documentation.ofelia.com
 [contributing.md]: https://github.com/bonitasoft/bonita-developer-resources/blob/master/CONTRIBUTING.MD
 
     

--- a/frontend/app/js/editor/bottom-panel/web-resources-panel/web-resource-popup.html
+++ b/frontend/app/js/editor/bottom-panel/web-resources-panel/web-resource-popup.html
@@ -41,7 +41,7 @@
             <div class="alert alert-info" role="alert">
                 <i class="fa fa-book fa-lg"></i>
                 <translate>You can check the list of all Bonita REST API resources on this dedicated <a
-                    href="https://api-documentation.bonitasoft.com/latest/">documentation</a>
+                    href="https://api-documentation.ofelia.com/latest/">documentation</a>
                 </translate>
             </div>
         </div>

--- a/frontend/app/js/editor/header/export-popup.html
+++ b/frontend/app/js/editor/header/export-popup.html
@@ -15,7 +15,7 @@
                 <b translate>Attention:</b>
                 <span translate>if you edit the page, form or layout outside the UI Designer, you will not be able to reimport it.</span>
                 <span translate>You will have to manage the minification and update the resources URL to trigger the cache busting.</span>
-                <span translate>For more information, consult the <a href="https://documentation.bonitasoft.com/?page=live-update#cache_busting">documentation</a>.</span>
+                <span translate>For more information, consult the <a href="https://documentation.ofelia.com/?page=live-update#cache_busting">documentation</a>.</span>
             </p>
         </div>
         <div class="checkbox">


### PR DESCRIPTION
Replace bonitasoft.com domain URLs with ofelia.com equivalents. No logic changes. Part of the Bonitasoft → Ofelia rebranding.