### PR TITLE
feat(jakarta)!: migrate the backend to the jakarta stack

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -13,9 +13,9 @@
     <packaging>pom</packaging>
 
     <properties>
-        <spring-boot.version>2.7.18</spring-boot.version>
+        <spring-boot.version>3.5.16</spring-boot.version>
         <handlebar.version>4.3.1</handlebar.version>
-        <ui-designer-artifact-builder.version>1.0.10</ui-designer-artifact-builder.version>
+        <ui-designer-artifact-builder.version>2.0.0-SNAPSHOT</ui-designer-artifact-builder.version>
     </properties>
 
     <modules>

--- a/backend/webapp/pom.xml
+++ b/backend/webapp/pom.xml
@@ -12,7 +12,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <smiley-http-proxy-servlet.version>1.12.1</smiley-http-proxy-servlet.version>
+        <smiley-http-proxy-servlet.version>2.0</smiley-http-proxy-servlet.version>
         <moco-junit.version>1.5.0</moco-junit.version>
         <resource.delimiter>@</resource.delimiter>
     </properties>

--- a/backend/webapp/src/main/java/org/bonitasoft/web/designer/Main.java
+++ b/backend/webapp/src/main/java/org/bonitasoft/web/designer/Main.java
@@ -4,7 +4,7 @@ import static org.springframework.util.StringUtils.hasText;
 
 import java.io.IOException;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.bonitasoft.web.designer.config.UiDesignerProperties;
 import org.bonitasoft.web.designer.config.WorkspaceProperties;

--- a/backend/webapp/src/main/java/org/bonitasoft/web/designer/config/DesignerConfig.java
+++ b/backend/webapp/src/main/java/org/bonitasoft/web/designer/config/DesignerConfig.java
@@ -16,7 +16,7 @@ package org.bonitasoft.web.designer.config;
 
 import java.util.List;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.apache.commons.io.monitor.FileAlterationMonitor;
 import org.bonitasoft.web.angularjs.GeneratorProperties;

--- a/backend/webapp/src/main/java/org/bonitasoft/web/designer/config/WebMvcConfiguration.java
+++ b/backend/webapp/src/main/java/org/bonitasoft/web/designer/config/WebMvcConfiguration.java
@@ -73,7 +73,7 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
     }
 
     /**
-     * To use multipart (based on Servlet 3.0) we need to mark the DispatcherServlet with a {@link javax.servlet.MultipartConfigElement} in programmatic Servlet
+     * To use multipart (based on Servlet 3.0) we need to mark the DispatcherServlet with a {@link jakarta.servlet.MultipartConfigElement} in programmatic Servlet
      * registration. Configuration settings such as maximum sizes or storage locations need to be applied at that Servlet registration level as Servlet 3.0 does
      * not allow for those settings to be done from the MultipartResolver.
      */

--- a/backend/webapp/src/main/java/org/bonitasoft/web/designer/controller/AssetResource.java
+++ b/backend/webapp/src/main/java/org/bonitasoft/web/designer/controller/AssetResource.java
@@ -34,8 +34,8 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Optional;
 

--- a/backend/webapp/src/main/java/org/bonitasoft/web/designer/controller/FragmentResource.java
+++ b/backend/webapp/src/main/java/org/bonitasoft/web/designer/controller/FragmentResource.java
@@ -25,7 +25,7 @@ import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 import java.io.IOException;
 import java.util.List;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.bonitasoft.web.designer.common.repository.exception.NotFoundException;
 import org.bonitasoft.web.designer.common.repository.exception.RepositoryException;

--- a/backend/webapp/src/main/java/org/bonitasoft/web/designer/controller/PageResource.java
+++ b/backend/webapp/src/main/java/org/bonitasoft/web/designer/controller/PageResource.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.bonitasoft.web.designer.common.repository.exception.NotFoundException;
 import org.bonitasoft.web.designer.common.repository.exception.RepositoryException;

--- a/backend/webapp/src/main/java/org/bonitasoft/web/designer/controller/PreviewController.java
+++ b/backend/webapp/src/main/java/org/bonitasoft/web/designer/controller/PreviewController.java
@@ -25,9 +25,9 @@ import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.bonitasoft.web.designer.ArtifactBuilder;
 import org.bonitasoft.web.designer.common.generator.rendering.GenerationException;

--- a/backend/webapp/src/main/java/org/bonitasoft/web/designer/controller/RequestMappingUtils.java
+++ b/backend/webapp/src/main/java/org/bonitasoft/web/designer/controller/RequestMappingUtils.java
@@ -17,7 +17,7 @@ package org.bonitasoft.web.designer.controller;
 
 import org.springframework.util.AntPathMatcher;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import static org.springframework.web.servlet.HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE;
 import static org.springframework.web.servlet.HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE;

--- a/backend/webapp/src/main/java/org/bonitasoft/web/designer/controller/ResponseHeadersHelper.java
+++ b/backend/webapp/src/main/java/org/bonitasoft/web/designer/controller/ResponseHeadersHelper.java
@@ -19,7 +19,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
 import java.net.URISyntaxException;
 

--- a/backend/webapp/src/main/java/org/bonitasoft/web/designer/controller/WidgetResource.java
+++ b/backend/webapp/src/main/java/org/bonitasoft/web/designer/controller/WidgetResource.java
@@ -20,8 +20,8 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.bonitasoft.web.designer.common.repository.exception.NotAllowedException;
 import org.bonitasoft.web.designer.common.repository.exception.NotFoundException;

--- a/backend/webapp/src/main/java/org/bonitasoft/web/designer/controller/preview/PreservingCookiePathProxyServlet.java
+++ b/backend/webapp/src/main/java/org/bonitasoft/web/designer/controller/preview/PreservingCookiePathProxyServlet.java
@@ -27,10 +27,10 @@ import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.protocol.BasicHttpContext;
 import org.mitre.dsmiley.httpproxy.ProxyServlet;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.HttpCookie;
 import java.net.MalformedURLException;

--- a/backend/webapp/src/main/java/org/bonitasoft/web/designer/controller/utils/HttpFile.java
+++ b/backend/webapp/src/main/java/org/bonitasoft/web/designer/controller/utils/HttpFile.java
@@ -16,8 +16,8 @@ package org.bonitasoft.web.designer.controller.utils;
 
 import org.springframework.http.MediaType;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;

--- a/backend/webapp/src/test/java/org/bonitasoft/web/designer/controller/PageResourceTest.java
+++ b/backend/webapp/src/test/java/org/bonitasoft/web/designer/controller/PageResourceTest.java
@@ -463,7 +463,8 @@ class PageResourceTest {
     void should_respond_202_with_error_when_uploading_a_json_asset_with_malformed_json_file() throws Exception {
         byte[] content = "notvalidjson".getBytes();
         MockMultipartFile file = aJsonFileWithContent(content);
-        int expectedLine = 1, expectedColumn = 13;
+        // Jackson 2.16+ (Boot 3.5) reports the START of the unrecognized token, not the position after it
+        int expectedLine = 1, expectedColumn = 1;
 
         mockMvc.perform(multipart("/rest/pages/my-page/assets/json").file(file))
                 .andExpect(status().isAccepted())

--- a/backend/webapp/src/test/java/org/bonitasoft/web/designer/controller/PreviewControllerTest.java
+++ b/backend/webapp/src/test/java/org/bonitasoft/web/designer/controller/PreviewControllerTest.java
@@ -34,7 +34,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static java.nio.file.Files.readAllBytes;
-import static javax.servlet.http.HttpServletResponse.SC_TEMPORARY_REDIRECT;
+import static jakarta.servlet.http.HttpServletResponse.SC_TEMPORARY_REDIRECT;
 import static junit.framework.Assert.assertEquals;
 import static org.bonitasoft.web.designer.builder.FragmentBuilder.aFragment;
 import static org.bonitasoft.web.designer.builder.PageBuilder.aPage;

--- a/backend/webapp/src/test/java/org/bonitasoft/web/designer/controller/ResourceControllerAdviceTest.java
+++ b/backend/webapp/src/test/java/org/bonitasoft/web/designer/controller/ResourceControllerAdviceTest.java
@@ -28,7 +28,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
-import javax.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolation;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;

--- a/backend/webapp/src/test/java/org/bonitasoft/web/designer/controller/WidgetResourceTest.java
+++ b/backend/webapp/src/test/java/org/bonitasoft/web/designer/controller/WidgetResourceTest.java
@@ -456,7 +456,7 @@ class WidgetResourceTest {
 
         when(widgetService.saveOrUpdateAsset(eq("my-widget"), eq(expectedAsset.getType()), eq(expectedAsset.getName()), any())).thenReturn(expectedAsset);
 
-        mockMvc.perform(fileUpload("/rest/widgets/my-widget/assets/js").file(file))
+        mockMvc.perform(multipart("/rest/widgets/my-widget/assets/js").file(file))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value("assetId"))
                 .andExpect(jsonPath("$.name").value("myfile.js"))


### PR DESCRIPTION
## What

Migrates bonita-ui-designer to the jakarta namespace: **Spring Boot 2.7.18 -> 3.5.16** (the same 3.5.x line as the engine and ui-designer-artifact-builder 2.0.0), **ui-designer-artifact-builder 1.0.10 -> 2.0.0-SNAPSHOT** and **smiley-http-proxy-servlet 1.12.1 -> 2.0**.

Implements BPA-786 (epic BPA-230). Companion of bonitasoft/bonita-ui-designer-artifact-builder#288.

**Draft until artifact-builder 2.0.0 is released** - the backend pom currently points at 2.0.0-SNAPSHOT; the version must be replaced by the released 2.0.0 before merge (and CI needs the artifact resolvable).

## Changes

- **Spring Boot BOM 2.7.18 -> 3.5.16** (`backend/pom.xml`): brings Spring Framework 6.2.x, embedded Tomcat 10.1, jakarta.* APIs. Java baseline was already 17.
- **ui-designer-artifact-builder 1.0.10 -> 2.0.0-SNAPSHOT**: the jakarta line of the library; its page/widget model classes carry jakarta.validation annotations, so the library bump and the Boot upgrade must land together (a javax-generation validator would silently see no constraints).
- **smiley-http-proxy-servlet 1.12.1 -> 2.0**: the jakarta.servlet variant. It stays on Apache HttpClient 4.5.x, so `PreservingCookiePathProxyServlet` (which overrides ProxyServlet methods using org.apache.http types) only needed the servlet import switch - no HttpClient 5 port.
- **javax -> jakarta imports** in 14 backend files: javax.servlet.* (proxy servlet, controllers, HttpFile, ResponseHeadersHelper), javax.annotation.PostConstruct (Main, DesignerConfig), javax.validation.ConstraintViolation (ResourceControllerAdviceTest).
- **Test adaptations to Spring 6 / Jackson 2.19**: `MockMvcRequestBuilders.fileUpload()` (removed in Spring 6) -> `multipart()`; Jackson 2.16+ reports the START of an unrecognized token in JsonLocation, so the malformed-json upload test now expects column 1 instead of 13.

Untouched on purpose:
- `WebSocketConfig` - pure Spring messaging abstractions, source-compatible.
- `application.properties` - all keys are still valid in Boot 3 (spring.servlet.multipart.*, server.servlet.context-path, management.*).
- The `dependencies` report profile still uses Groovy 3 + groovy-jaxb (report tooling only, not shipped; can move to Groovy 4 with the bonita-project alignment later).

## Behavior notes

- Boot 3 / Spring 6 no longer matches trailing slashes on controller mappings (`GET /rest/pages/` != `GET /rest/pages`). The UID frontend calls exact paths, but any external caller relying on trailing slashes will now 404.
- The malformed-JSON error location reported to the user now points at the start of the offending token (Jackson upstream improvement).

## Verification

- `./mvnw test -pl backend/webapp -am`: **374 tests, 0 failures** on the jakarta stack (artifact-builder 2.0.0-SNAPSHOT built locally from bonitasoft/bonita-ui-designer-artifact-builder#288).
- Grep gate: zero `javax.servlet|javax.validation|javax.annotation.PostConstruct` references left in `backend/`.
- Still to do before merge (tracked on BPA-786): end-to-end run launched from the Studio (page edit, preview, artifact build), and the same evaluation for bonita-ui-designer-internal.